### PR TITLE
Update parameters for devnet

### DIFF
--- a/artifacts/devnet/miner/config.json
+++ b/artifacts/devnet/miner/config.json
@@ -50,11 +50,12 @@
     "sync-validation-delta": 30,
     "hdist": 10,
     "atxs-per-block": 25,
-    "tortoise-rerun-interval": 525600
+    "tortoise-window-size": 30,
+    "tortoise-rerun-interval": 60
   },
   "p2p": {
     "network-id": 777,
-    "target-outbound": 20
+    "target-outbound": 10
   },
   "post": {
     "post-bits-per-label": 8,


### PR DESCRIPTION
- rerun tortoise from scratch every hour
- reduce the number of blocks that we keep in memory before verified layer
  as discussed with research this window is only relevant for self-healing
  we are taking a different approach with self-healing, so eventually, this window will be rework
  but for now, we can minimize it to use fewer resources
- reduce target-outbound from 20 to 10
  that was an unnecessary change