### PR TITLE
config: set verification window to a 100/10 for verifying and full tortoise

### DIFF
--- a/artifacts/devnet/miner/config.json
+++ b/artifacts/devnet/miner/config.json
@@ -55,10 +55,6 @@
     "network-id": 210,
     "target-outbound": 10
   },
-  "tortoise": {
-    "tortoise-window-size": 30,
-    "tortoise-rerun-interval": 60
-  },
   "post": {
     "post-bits-per-label": 8,
     "post-labels-per-unit": 1024,

--- a/artifacts/devnet/miner/config.json
+++ b/artifacts/devnet/miner/config.json
@@ -55,6 +55,10 @@
     "network-id": 210,
     "target-outbound": 10
   },
+  "tortoise": {
+    "full-mode-verification-window": 10,
+    "verifying-mode-verification-window": 100
+  },
   "post": {
     "post-bits-per-label": 8,
     "post-labels-per-unit": 1024,


### PR DESCRIPTION
other values are removed because now we will have reasonable default.

related to https://github.com/spacemeshos/go-spacemesh/issues/3009