### PR TITLE
Update GKE to supported version

### DIFF
--- a/gcp/gke.go
+++ b/gcp/gke.go
@@ -138,7 +138,7 @@ func CreateKubernetesCluster() error {
 		Cluster: &containerpb.Cluster{
 			Name:                  config.NetworkName,
 			NodePools:             nodePools,
-			InitialClusterVersion: "1.19.15-gke.500", //https://cloud.google.com/kubernetes-engine/docs/release-notes
+			InitialClusterVersion: "1.20.11-gke.1300", //https://cloud.google.com/kubernetes-engine/docs/release-notes
 			ReleaseChannel: &containerpb.ReleaseChannel{
 				Channel: containerpb.ReleaseChannel_UNSPECIFIED,
 			},


### PR DESCRIPTION
If we checkout the repo as is (without this fix) and then try to create a network we'll get an error:
```
creating k8s cluster
rpc error: code = InvalidArgument desc = Master version "1.19.15-gke.500" is unsupported.
```

This tiny fix bumps the version to the actual one and the error goes away.